### PR TITLE
Fix set-cookie attributes in set() and remove() methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ class VueCookiesManager implements VueCookies {
         ? "; path=" + path
         : this.current_default_config.path
         ? "; path=" + this.current_default_config.path
-        : "; path=/") +
+        : "") +
       (secure
         ? "; Secure"
         : this.current_default_config.secure
@@ -185,7 +185,7 @@ class VueCookiesManager implements VueCookies {
         ? "; path=" + path
         : this.current_default_config.path
         ? "; path=" + this.current_default_config.path
-        : "; path=/") +
+        : "") +
       "; SameSite=Lax";
     return true;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,19 +156,15 @@ class VueCookiesManager implements VueCookies {
         : this.current_default_config.path
         ? "; path=" + this.current_default_config.path
         : "; path=/") +
-      (secure == undefined
-        ? this.current_default_config.secure
-          ? "; Secure"
-          : ""
-        : secure
+      (secure
+        ? "; Secure"
+        : this.current_default_config.secure
         ? "; Secure"
         : "") +
-      (sameSite == undefined
-        ? this.current_default_config.sameSite
-          ? "; SameSite=" + this.current_default_config.sameSite
-          : ""
-        : sameSite
+      (sameSite
         ? "; SameSite=" + sameSite
+        : this.current_default_config.sameSite
+        ? "; SameSite=" + this.current_default_config.sameSite
         : "");
     return this;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,10 @@ import { reactive } from "vue";
 
 const defaultConfig: CookiesConfig = {
   expireTimes: "1d",
-  path: "; path=/",
+  path: "/",
   domain: "",
   secure: false,
-  sameSite: "; SameSite=Lax",
+  sameSite: "Lax",
 };
 
 class VueCookiesManager implements VueCookies {
@@ -149,12 +149,12 @@ class VueCookiesManager implements VueCookies {
       (domain
         ? "; domain=" + domain
         : this.current_default_config.domain
-        ? this.current_default_config.domain
+        ? "; domain=" + this.current_default_config.domain
         : "") +
       (path
         ? "; path=" + path
         : this.current_default_config.path
-        ? this.current_default_config.path
+        ? "; path=" + this.current_default_config.path
         : "; path=/") +
       (secure == undefined
         ? this.current_default_config.secure
@@ -165,7 +165,7 @@ class VueCookiesManager implements VueCookies {
         : "") +
       (sameSite == undefined
         ? this.current_default_config.sameSite
-          ? this.current_default_config.sameSite
+          ? "; SameSite=" + this.current_default_config.sameSite
           : ""
         : sameSite
         ? "; SameSite=" + sameSite
@@ -183,12 +183,12 @@ class VueCookiesManager implements VueCookies {
       (domain
         ? "; domain=" + domain
         : this.current_default_config.domain
-        ? this.current_default_config.domain
+        ? "; domain=" + this.current_default_config.domain
         : "") +
       (path
         ? "; path=" + path
         : this.current_default_config.path
-        ? this.current_default_config.path
+        ? "; path=" + this.current_default_config.path
         : "; path=/") +
       "; SameSite=Lax";
     return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ class VueCookiesManager implements VueCookies {
         : "") +
       (sameSite == undefined
         ? this.current_default_config.sameSite
-          ? "; SameSute=" + this.current_default_config.sameSite
+          ? this.current_default_config.sameSite
           : ""
         : sameSite
         ? "; SameSite=" + sameSite


### PR DESCRIPTION
* Fix typo in SameSite parameter
* Cleanup logic in `VueCookies.set()` method to be consistent
* Remove including key names within the default config values - config values should just contain the value to set the parameter to, not the whole key-value pair
* Do not set a path when parameter is falsy

Fixes #9 and #7